### PR TITLE
Correct formatting in error message for missing option

### DIFF
--- a/src/main/java/com/github/ryenus/rop/OptionParser.java
+++ b/src/main/java/com/github/ryenus/rop/OptionParser.java
@@ -242,7 +242,7 @@ public class OptionParser {
 	private void parseOpt(String option, ListIterator<String> liter, OptionType optionType) {
 		OptionInfo optionInfo = cci.map.get(option);
 		if (optionInfo == null) {
-			throw new IllegalArgumentException(String.format("Unknown option '%s", option));
+			throw new IllegalArgumentException(String.format("Unknown option '%s'", option));
 		}
 
 		Field field = optionInfo.field;


### PR DESCRIPTION
Fixes missing `'` in:

```
Caused by: java.lang.IllegalArgumentException: Unknown option 'petty
	at com.github.ryenus.rop.OptionParser.parseOpt(OptionParser.java:245)
	at com.github.ryenus.rop.OptionParser.parse(OptionParser.java:206)
	at com.github.ryenus.rop.OptionParser.parse(OptionParser.java:137)
[...]
```